### PR TITLE
[Bug] Prevent panic on missing command arguments

### DIFF
--- a/commands/benchmark/cmd.go
+++ b/commands/benchmark/cmd.go
@@ -8,12 +8,24 @@ import (
 
 type Command struct {
 	subCommand string
+	showHelp   bool
 }
 
-func NewBenchmarkCommand(subCommand string) *Command {
-	return &Command{subCommand: subCommand}
+func NewCommand(args []string) *Command {
+	if len(args) == 0 {
+		return &Command{showHelp: true}
+	}
+	return &Command{subCommand: args[0]}
 }
 
 func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+	if cmd.showHelp {
+		cmd.Help()
+		return
+	}
 	//client := doptApi.NewBenchmarkServiceClient(conn)
+}
+
+func (cmd Command) Help() {
+	Help()
 }

--- a/commands/command.go
+++ b/commands/command.go
@@ -15,6 +15,7 @@ import (
 
 type Command interface {
 	Execute(conn *grpc.ClientConn, opts map[string]string)
+	Help()
 }
 
 func Run(input []string) {
@@ -75,40 +76,21 @@ func getCommand(input []string) Command {
 	}
 
 	var commandName = input[0]
+	var args = input[1:]
 
 	switch commandName {
 	case "benchmark":
-		if len(input) < 2 {
-			help([]string{"benchmark"})
-			return nil
-		}
-		return benchmark.NewBenchmarkCommand(input[1])
+		return benchmark.NewCommand(args)
 	case "context":
-		if len(input) < 2 {
-			help([]string{"context"})
-			return nil
-		}
-		return context.NewContextCommand(input[1], input[2:])
+		return context.NewCommand(args)
 	case "describe":
-		if len(input) < 3 {
-			help([]string{"describe"})
-			return nil
-		}
-		return describe.NewDescribeCommand(input[1], input[2])
+		return describe.NewCommand(args)
 	case "list":
-		if len(input) < 2 {
-			help([]string{"list"})
-			return nil
-		}
-		return list.NewListCommand(input[1])
+		return list.NewCommand(args)
 	case "simulation":
-		if len(input) < 2 {
-			help([]string{"simulation"})
-			return nil
-		}
-		return simulation.NewSimulationCommand(input[1], input[2:])
+		return simulation.NewCommand(args)
 	case "help":
-		help(input[1:])
+		help(args)
 	default:
 		Help()
 	}

--- a/commands/command.go
+++ b/commands/command.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"log"
-	"os"
 	"strings"
 )
 
@@ -70,18 +69,43 @@ func getConnection(serverAddr string) *grpc.ClientConn {
 }
 
 func getCommand(input []string) Command {
+	if len(input) == 0 {
+		Help()
+		return nil
+	}
+
 	var commandName = input[0]
 
 	switch commandName {
 	case "benchmark":
+		if len(input) < 2 {
+			help([]string{"benchmark"})
+			return nil
+		}
 		return benchmark.NewBenchmarkCommand(input[1])
 	case "context":
+		if len(input) < 2 {
+			help([]string{"context"})
+			return nil
+		}
 		return context.NewContextCommand(input[1], input[2:])
 	case "describe":
+		if len(input) < 3 {
+			help([]string{"describe"})
+			return nil
+		}
 		return describe.NewDescribeCommand(input[1], input[2])
 	case "list":
+		if len(input) < 2 {
+			help([]string{"list"})
+			return nil
+		}
 		return list.NewListCommand(input[1])
 	case "simulation":
+		if len(input) < 2 {
+			help([]string{"simulation"})
+			return nil
+		}
 		return simulation.NewSimulationCommand(input[1], input[2:])
 	case "help":
 		help(input[1:])
@@ -113,6 +137,4 @@ func help(input []string) {
 	} else {
 		Help()
 	}
-
-	os.Exit(0)
 }

--- a/commands/command_test.go
+++ b/commands/command_test.go
@@ -7,8 +7,6 @@ import (
 // TestRun_NoPanics verifies that the CLI doesn't panic on global options or unknown commands.
 // This test addresses Issue #2: [Bug] Fix panics and nil dereferences in commands package.
 func TestRun_NoPanics(t *testing.T) {
-	t.Skip("Disabled as requested by user. Addressing Issue #2.")
-
 	t.Run("GlobalOptsNoPanic", func(t *testing.T) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -25,5 +23,50 @@ func TestRun_NoPanics(t *testing.T) {
 			}
 		}()
 		Run([]string{"unknown-command"})
+	})
+
+	t.Run("ContextMissingArgsNoPanic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Run panicked: %v", r)
+			}
+		}()
+		Run([]string{"context"})
+	})
+
+	t.Run("ListMissingArgsNoPanic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Run panicked: %v", r)
+			}
+		}()
+		Run([]string{"list"})
+	})
+
+	t.Run("DescribeMissingArgsNoPanic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Run panicked: %v", r)
+			}
+		}()
+		Run([]string{"describe"})
+	})
+
+	t.Run("SimulationMissingArgsNoPanic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Run panicked: %v", r)
+			}
+		}()
+		Run([]string{"simulation"})
+	})
+
+	t.Run("BenchmarkMissingArgsNoPanic", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Run panicked: %v", r)
+			}
+		}()
+		Run([]string{"benchmark"})
 	})
 }

--- a/commands/context/cmd.go
+++ b/commands/context/cmd.go
@@ -9,10 +9,14 @@ type Command struct {
 	commandType string
 	args        []string
 	opts        map[string]string
+	showHelp    bool
 }
 
-func NewContextCommand(commandType string, args []string) *Command {
-	var command = &Command{commandType: commandType, args: args, opts: make(map[string]string)}
+func NewCommand(args []string) *Command {
+	if len(args) == 0 {
+		return &Command{showHelp: true}
+	}
+	var command = &Command{commandType: args[0], args: args[1:], opts: make(map[string]string)}
 
 	for _, arg := range command.args {
 		if arg == "--set-current" || arg == "-s" {
@@ -24,14 +28,29 @@ func NewContextCommand(commandType string, args []string) *Command {
 }
 
 func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+	if cmd.showHelp {
+		cmd.Help()
+		return
+	}
+
 	switch cmd.commandType {
 	case "list":
 		listContexts()
 	case "configure":
 		configureNewContext(cmd.opts)
 	case "set":
+		if len(cmd.args) == 0 {
+			cmd.Help()
+			return
+		}
 		setCurrentContext(cmd.args[0])
+	default:
+		cmd.Help()
 	}
+}
+
+func (cmd Command) Help() {
+	Help()
 }
 
 func listContexts() {

--- a/commands/describe/cmd.go
+++ b/commands/describe/cmd.go
@@ -8,13 +8,22 @@ import (
 type Command struct {
 	entityType string
 	entityId   string
+	showHelp   bool
 }
 
-func NewDescribeCommand(entityType string, entityId string) (cmd *Command) {
-	return &Command{entityType: entityType, entityId: entityId}
+func NewCommand(args []string) *Command {
+	if len(args) < 2 {
+		return &Command{showHelp: true}
+	}
+	return &Command{entityType: args[0], entityId: args[1]}
 }
 
 func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+	if cmd.showHelp {
+		cmd.Help()
+		return
+	}
+
 	switch cmd.entityType {
 	case "agent":
 		client := api.NewAgentServiceClient(conn)
@@ -22,7 +31,13 @@ func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
 	case "region":
 		client := api.NewRegionServiceClient(conn)
 		describeRegion(client)
+	default:
+		cmd.Help()
 	}
+}
+
+func (cmd Command) Help() {
+	Help()
 }
 
 func describeAgent(client api.AgentServiceClient) {

--- a/commands/list/cmd.go
+++ b/commands/list/cmd.go
@@ -12,13 +12,22 @@ import (
 
 type Command struct {
 	entityType string
+	showHelp   bool
 }
 
-func NewListCommand(entityType string) Command {
-	return Command{entityType: entityType}
+func NewCommand(args []string) *Command {
+	if len(args) == 0 {
+		return &Command{showHelp: true}
+	}
+	return &Command{entityType: args[0]}
 }
 
 func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+	if cmd.showHelp {
+		cmd.Help()
+		return
+	}
+
 	switch cmd.entityType {
 	case "agents":
 		agentClient := doptApi.NewAgentServiceClient(conn)
@@ -26,7 +35,13 @@ func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
 	case "regions":
 		regionClient := doptApi.NewRegionServiceClient(conn)
 		listRegions(regionClient)
+	default:
+		cmd.Help()
 	}
+}
+
+func (cmd Command) Help() {
+	Help()
 }
 
 func listAgents(client doptApi.AgentServiceClient) {

--- a/commands/simulation/cmd.go
+++ b/commands/simulation/cmd.go
@@ -14,13 +14,22 @@ import (
 type Command struct {
 	subCommand string
 	params     []string
+	showHelp   bool
 }
 
-func NewSimulationCommand(subCommand string, params []string) *Command {
-	return &Command{subCommand: subCommand, params: params}
+func NewCommand(args []string) *Command {
+	if len(args) == 0 {
+		return &Command{showHelp: true}
+	}
+	return &Command{subCommand: args[0], params: args[1:]}
 }
 
 func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+	if cmd.showHelp {
+		cmd.Help()
+		return
+	}
+
 	switch cmd.subCommand {
 	case "status":
 		cmd.handleStatus(conn)
@@ -31,8 +40,12 @@ func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
 	case "extractData":
 		cmd.handleExtractData(conn)
 	default:
-		log.Fatalf("Unknown simulation subcommand: %s", cmd.subCommand)
+		cmd.Help()
 	}
+}
+
+func (cmd Command) Help() {
+	Help()
 }
 
 func (cmd Command) handleStatus(conn *grpc.ClientConn) {
@@ -49,7 +62,8 @@ func (cmd Command) handleStatus(conn *grpc.ClientConn) {
 
 func (cmd Command) handleStart(conn *grpc.ClientConn) {
 	if len(cmd.params) < 1 {
-		log.Fatal("Missing configuration file path")
+		cmd.Help()
+		return
 	}
 	configPath := cmd.params[0]
 	content, err := os.ReadFile(configPath)

--- a/commands/simulation/cmd_test.go
+++ b/commands/simulation/cmd_test.go
@@ -58,7 +58,7 @@ func TestSimulationCommand_Execute(t *testing.T) {
 
 	// Test status
 	t.Run("status", func(t *testing.T) {
-		cmd := NewSimulationCommand("status", nil)
+		cmd := NewCommand([]string{"status"})
 		cmd.Execute(conn, nil)
 		if mockServer.lastMethod != "StatSimulation" {
 			t.Errorf("Expected method StatSimulation, got %s", mockServer.lastMethod)
@@ -67,7 +67,7 @@ func TestSimulationCommand_Execute(t *testing.T) {
 
 	// Test stop
 	t.Run("stop", func(t *testing.T) {
-		cmd := NewSimulationCommand("stop", nil)
+		cmd := NewCommand([]string{"stop"})
 		cmd.Execute(conn, nil)
 		if mockServer.lastMethod != "StopSimulation" {
 			t.Errorf("Expected method StopSimulation, got %s", mockServer.lastMethod)
@@ -89,7 +89,7 @@ func TestSimulationCommand_Execute(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cmd := NewSimulationCommand("start", []string{tmpfile.Name()})
+		cmd := NewCommand([]string{"start", tmpfile.Name()})
 		cmd.Execute(conn, nil)
 		if mockServer.lastMethod != "StartSimulation" {
 			t.Errorf("Expected method StartSimulation, got %s", mockServer.lastMethod)

--- a/plans/P003-fix-command-panic.md
+++ b/plans/P003-fix-command-panic.md
@@ -1,0 +1,26 @@
+# P003 - Fix Command Panic
+
+## Objective
+Fix the runtime panic in `doptctl` caused by executing commands without the required subcommands or arguments (Issue #12). Specifically, when a command is missing arguments, the CLI should print the help documentation instead of crashing.
+
+## Key Files & Context
+- `commands/command.go`: Central command dispatcher that currently lacks slice bounds checking.
+
+## Implementation Steps
+1. Modify `getCommand(input []string) Command` in `commands/command.go`:
+   - Add a check for `len(input) == 0` at the beginning of the function. If true, call the global `Help()` and return.
+   - For each case (`benchmark`, `context`, `describe`, `list`, `simulation`), verify the length of `input` before accessing indices like `input[1]` or `input[2]`.
+   - If the required arguments are missing, redirect to the `help` function with the specific `commandName` to print the command's help message.
+
+### Example logic for length checks
+- `benchmark`, `context`, `list`, `simulation`: Requires `len(input) >= 2`.
+- `describe`: Requires `len(input) >= 3` because it uses `input[1]` (entity type) and `input[2]` (entity ID).
+
+2. Modify `commands/command_test.go` (Optional/Bonus):
+   - Add test cases to verify that `doptctl context`, `doptctl list`, etc. do not panic when run with missing arguments.
+
+## Verification & Testing
+- Run `doptctl context` and verify it prints the context help.
+- Run `doptctl list` and verify it prints the list help.
+- Run `doptctl describe` and verify it prints the describe help.
+- Run `go test ./...` to ensure no panics occur.

--- a/plans/P004-refactor-command-pattern.md
+++ b/plans/P004-refactor-command-pattern.md
@@ -1,0 +1,53 @@
+# P004 - Refactor Command Pattern
+
+## Objective
+Address the structural anti-pattern identified in PR #13 (repetitive `if` statements in `getCommand` for argument validation). The goal is to move validation logic into the individual commands so that they are aware of their expected parameters and display their own help when arguments are missing. This also involves modifying the command interface so that subcommand execution logic is defined at the constructor level.
+
+## Key Files & Context
+- `commands/command.go`: Central dispatcher and `Command` interface.
+- `commands/benchmark/cmd.go`, `commands/context/cmd.go`, `commands/describe/cmd.go`, `commands/list/cmd.go`, `commands/simulation/cmd.go`: Subcommand packages.
+
+## Implementation Steps
+1. **Update `Command` Interface**
+   Modify `Command` in `commands/command.go` to include a `Help()` method:
+   ```go
+   type Command interface {
+       Execute(conn *grpc.ClientConn, opts map[string]string)
+       Help()
+   }
+   ```
+
+2. **Simplify Central Dispatcher**
+   Refactor `getCommand` in `commands/command.go` to pass the remaining `input` arguments directly to the subcommand constructors, removing all bounds checks from the central dispatcher:
+   ```go
+   func getCommand(input []string) Command {
+       if len(input) == 0 {
+           Help()
+           return nil
+       }
+       cmdName := input[0]
+       args := input[1:]
+       switch cmdName {
+       case "benchmark": return benchmark.NewCommand(args)
+       case "context": return context.NewCommand(args)
+       case "describe": return describe.NewCommand(args)
+       case "list": return list.NewCommand(args)
+       case "simulation": return simulation.NewCommand(args)
+       case "help": return help(args)
+       default: Help(); return nil
+       }
+   }
+   ```
+
+3. **Refactor Subcommand Constructors and Types**
+   For each sub-package (`benchmark`, `context`, `describe`, `list`, `simulation`), implement the Command pattern properly:
+   - Change `NewXxxCommand` to `NewCommand(args []string) commands.Command`.
+   - Update the existing command structs to implement `Help()`.
+   - If the constructor receives an empty `args` slice (or missing required positional arguments), it should return an instance of a dedicated "Help Command" or configure the main command to execute the `Help()` function instead of proceeding with gRPC calls.
+
+4. **Adjust `commands/command_test.go`**
+   Update tests to reflect the new constructor signatures and ensure the "no panic" behavior is maintained.
+
+## Verification & Testing
+- Run `doptctl context`, `doptctl list`, `doptctl describe`, etc. without arguments and verify they display the specific help menu.
+- Ensure the test suite passes (`go test ./...`).


### PR DESCRIPTION
### Context
Running the `doptctl` subcommands (context, list, etc.) without the required arguments caused a runtime panic due to out-of-bounds slice access. This PR fixes the panic and refactors the command structure to follow a cleaner, more idiomatic Command pattern.

### Technical Approach
- **Refactored Command Pattern**: Moved argument validation and subcommand selection from the central `getCommand` into individual subcommand constructors (`NewCommand`).
- **Self-Aware Commands**: Commands are now responsible for validating their own parameters. If arguments are missing or invalid, they display their own `Help()` content.
- **Interface Update**: Added `Help()` to the `Command` interface to allow uniform help invocation.
- **Consistency**: Renamed various `NewXxxCommand` functions to `NewCommand` for a consistent API across sub-packages.
- **Improved Testing**: Updated tests to reflect the new structure while maintaining the "no-panic" verification.

### Acceptance Criteria
- [x] `doptctl <command>` without args displays command-specific help.
- [x] `doptctl <command> <subcommand>` without required positional args displays help.
- [x] No runtime panics on missing arguments.
- [x] `go test ./...` passes.

Fixes #12
