### PR TITLE
[Refactor] Standardize error handling and architectural cleanup

### DIFF
--- a/commands/benchmark/cmd.go
+++ b/commands/benchmark/cmd.go
@@ -18,12 +18,13 @@ func NewCommand(args []string) *Command {
 	return &Command{subCommand: args[0]}
 }
 
-func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) error {
 	if cmd.showHelp {
 		cmd.Help()
-		return
+		return nil
 	}
 	//client := doptApi.NewBenchmarkServiceClient(conn)
+	return nil
 }
 
 func (cmd Command) Help() {

--- a/commands/command.go
+++ b/commands/command.go
@@ -6,15 +6,15 @@ import (
 	"doptctl/commands/describe"
 	"doptctl/commands/list"
 	"doptctl/commands/simulation"
+	"doptctl/doptimas/client"
 	"fmt"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"log"
+	"os"
 	"strings"
 )
 
 type Command interface {
-	Execute(conn *grpc.ClientConn, opts map[string]string)
+	Execute(conn *grpc.ClientConn, opts map[string]string) error
 	Help()
 }
 
@@ -42,31 +42,31 @@ func Run(input []string) {
 	// context commands operate over local files, and change current context
 	// this if prevents loading the current context
 	if input[lastIndex] == "context" {
-		command.Execute(nil, nil)
+		err := command.Execute(nil, nil)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 	} else {
-		ctx, error := context.LoadContext()
+		ctx, err := context.LoadContext()
 
-		if error != nil {
-			log.Fatalf("Couldn't load current context")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
 		}
 
-		conn := getConnection(ctx.URL())
+		conn, err := client.NewConnection(ctx.URL())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error connecting to %s: %v\n", ctx.URL(), err)
+			os.Exit(1)
+		}
 		defer conn.Close()
-		command.Execute(conn, globalOpts)
+		err = command.Execute(conn, globalOpts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
 	}
-}
-
-func getConnection(serverAddr string) *grpc.ClientConn {
-	var opts []grpc.DialOption
-
-	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-
-	conn, err := grpc.Dial(serverAddr, opts...)
-	if err != nil {
-		log.Fatalf("fail to dial: %v", err)
-	}
-
-	return conn
 }
 
 func getCommand(input []string) Command {

--- a/commands/context/cmd.go
+++ b/commands/context/cmd.go
@@ -1,7 +1,7 @@
 package context
 
 import (
-	"fmt"
+	"doptctl/commands/output"
 	"google.golang.org/grpc"
 )
 
@@ -27,25 +27,26 @@ func NewCommand(args []string) *Command {
 	return command
 }
 
-func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) error {
 	if cmd.showHelp {
 		cmd.Help()
-		return
+		return nil
 	}
 
 	switch cmd.commandType {
 	case "list":
-		listContexts()
+		return listContexts()
 	case "configure":
-		configureNewContext(cmd.opts)
+		return configureNewContext(cmd.opts)
 	case "set":
 		if len(cmd.args) == 0 {
 			cmd.Help()
-			return
+			return nil
 		}
-		setCurrentContext(cmd.args[0])
+		return setCurrentContext(cmd.args[0])
 	default:
 		cmd.Help()
+		return nil
 	}
 }
 
@@ -53,21 +54,40 @@ func (cmd Command) Help() {
 	Help()
 }
 
-func listContexts() {
-	ctxs := getAllContexts()
+func listContexts() error {
+	ctxs, err := getAllContexts()
+	if err != nil {
+		return err
+	}
 
+	header := []string{"", "Name", "Host", "Port"}
+	data := [][]string{}
 	for _, ctx := range ctxs {
-		fmt.Println(ctx.Name + ", " + ctx.Host + ", " + ctx.Port)
+		currentIndicator := ""
+		if ctx.current {
+			currentIndicator = "*"
+		}
+		data = append(data, []string{currentIndicator, ctx.Name, ctx.Host, ctx.Port})
 	}
+
+	output.PrintTable(header, data)
+	return nil
 }
 
-func configureNewContext(opts map[string]string) {
-	ctx := createNewContext()
+func configureNewContext(opts map[string]string) error {
+	ctx, err := createNewContext()
+	if err != nil {
+		return err
+	}
+	if ctx == nil {
+		return nil
+	}
 	if _, ok := opts["--set-current"]; ok {
-		setCurrentContext(ctx.Name)
+		return setCurrentContext(ctx.Name)
 	}
+	return nil
 }
 
-func setCurrentContext(contextName string) {
-	overrideCurrentContext(contextName)
+func setCurrentContext(contextName string) error {
+	return overrideCurrentContext(contextName)
 }

--- a/commands/context/context.go
+++ b/commands/context/context.go
@@ -28,11 +28,14 @@ var (
 )
 
 func LoadContext() (ClientContext, error) {
-	ctx, error := readContext("current.json")
+	ctx, err := readContext("current.json")
 
-	if os.IsNotExist(error) {
-		log.Fatal("No Current context set. Try running doptctl context configure or doptctl context set")
-		os.Exit(1)
+	if os.IsNotExist(err) {
+		return ClientContext{}, fmt.Errorf("no current context set. Try running doptctl context configure or doptctl context set")
+	}
+
+	if err != nil {
+		return ClientContext{}, fmt.Errorf("couldn't load current context: %w", err)
 	}
 
 	setContext(ctx)
@@ -40,37 +43,39 @@ func LoadContext() (ClientContext, error) {
 	return *ctx, nil
 }
 
-func initializeContextDir() {
-	_, error := os.Stat(doptctlContextDir)
-	if os.IsNotExist(error) {
+func initializeContextDir() error {
+	_, err := os.Stat(doptctlContextDir)
+	if os.IsNotExist(err) {
 		log.Println("Dir doesn't exist, creating it")
-		error := os.MkdirAll(doptctlContextDir, os.ModePerm)
-		if error != nil {
-			log.Fatal("Couldn't create context dir")
-			os.Exit(1)
+		err := os.MkdirAll(doptctlContextDir, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("couldn't create context dir: %w", err)
 		}
-
 	}
+	return nil
 }
 
-func createNewContext() *ClientContext {
+func createNewContext() (*ClientContext, error) {
 	var newContext ClientContext
 	var confirm string
 
-	initializeContextDir()
+	err := initializeContextDir()
+	if err != nil {
+		return nil, err
+	}
 
 	fmt.Println("Context Name: ")
 	fmt.Scanln(&newContext.Name)
 
 	newContextFilePath := filepath.Join(doptctlContextDir, newContext.Name+".json")
 
-	_, error := os.Stat(newContextFilePath)
+	_, err = os.Stat(newContextFilePath)
 
-	if error == nil {
+	if err == nil {
 		fmt.Println("Context already exists, do you wanna override it[Y/n]?")
 		fmt.Scanln(&confirm)
 		if confirm == "n" {
-			return nil
+			return nil, nil
 		}
 	}
 
@@ -80,38 +85,39 @@ func createNewContext() *ClientContext {
 	fmt.Print("D-Optimas Port: ")
 	fmt.Scanln(&newContext.Port)
 
-	writeContext(newContext)
+	err = writeContext(newContext)
+	if err != nil {
+		return nil, err
+	}
 
-	return &newContext
+	return &newContext, nil
 }
 
-func overrideCurrentContext(contextName string) {
-	currentContextFile, error := os.Create(doptctlContextFile)
+func overrideCurrentContext(contextName string) error {
+	currentContextFile, err := os.Create(doptctlContextFile)
 
-	if error != nil {
-		log.Fatal("Couldn't open Current context file")
-		os.Exit(1)
+	if err != nil {
+		return fmt.Errorf("couldn't open current context file: %w", err)
 	}
 	defer currentContextFile.Close()
 
-	ctxFile, error := os.Open(filepath.Join(doptctlContextDir, contextName+".json"))
+	ctxFile, err := os.Open(filepath.Join(doptctlContextDir, contextName+".json"))
 
-	if error != nil {
-		log.Fatal("Couldn't open " + contextName + " context file")
-		os.Exit(1)
+	if err != nil {
+		return fmt.Errorf("couldn't open %s context file: %w", contextName, err)
 	}
 	defer ctxFile.Close()
 
-	io.Copy(currentContextFile, ctxFile)
+	_, err = io.Copy(currentContextFile, ctxFile)
+	return err
 }
 
-func getAllContexts() []ClientContext {
-	files, error := os.ReadDir(doptctlContextDir)
+func getAllContexts() ([]ClientContext, error) {
+	files, err := os.ReadDir(doptctlContextDir)
 	var doptctlContexts []ClientContext
 
-	if error != nil {
-		log.Fatal("Could not read doptctl context dir")
-		os.Exit(1)
+	if err != nil {
+		return nil, fmt.Errorf("could not read doptctl context dir: %w", err)
 	}
 
 	current, _ := readContext("current.json")
@@ -120,9 +126,8 @@ func getAllContexts() []ClientContext {
 		if file.IsDir() || file.Name() == "current.json" {
 			continue
 		}
-		fmt.Println(file.Name())
-		ctx, error := readContext(file.Name())
-		if error == nil {
+		ctx, err := readContext(file.Name())
+		if err == nil {
 			if current != nil && ctx.Name == current.Name {
 				ctx.current = true
 			}
@@ -130,26 +135,24 @@ func getAllContexts() []ClientContext {
 		}
 	}
 
-	return doptctlContexts
+	return doptctlContexts, nil
 }
 
-func writeContext(ctx ClientContext) {
+func writeContext(ctx ClientContext) error {
 	ctxFilePath := filepath.Join(doptctlContextDir, ctx.Name+".json")
 	ctxBytes, marshalError := json.Marshal(ctx)
-	newContextFile, fileError := os.Create(ctxFilePath)
-
 	if marshalError != nil {
-		log.Fatal("Couldn't marshal context to json")
-		os.Exit(1)
+		return fmt.Errorf("couldn't marshal context to json: %w", marshalError)
 	}
 
+	newContextFile, fileError := os.Create(ctxFilePath)
 	if fileError != nil {
-		log.Fatal("Couldn't create new context file ", ctxFilePath)
-		os.Exit(1)
+		return fmt.Errorf("couldn't create new context file %s: %w", ctxFilePath, fileError)
 	}
 	defer newContextFile.Close()
 
-	newContextFile.Write(ctxBytes)
+	_, err := newContextFile.Write(ctxBytes)
+	return err
 }
 
 func readContext(fileName string) (*ClientContext, error) {

--- a/commands/describe/cmd.go
+++ b/commands/describe/cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"doptctl/commands/output"
 	"fmt"
-	"log"
 
 	"github.com/felipedreis/doptimas-proto-go/api"
 	"google.golang.org/grpc"
@@ -23,21 +22,22 @@ func NewCommand(args []string) *Command {
 	return &Command{entityType: args[0], entityId: args[1]}
 }
 
-func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) error {
 	if cmd.showHelp {
 		cmd.Help()
-		return
+		return nil
 	}
 
 	switch cmd.entityType {
 	case "agent":
 		client := api.NewAgentServiceClient(conn)
-		cmd.describeAgent(client)
+		return cmd.describeAgent(client)
 	case "region":
 		client := api.NewRegionServiceClient(conn)
-		cmd.describeRegion(client)
+		return cmd.describeRegion(client)
 	default:
 		cmd.Help()
+		return nil
 	}
 }
 
@@ -45,11 +45,11 @@ func (cmd Command) Help() {
 	Help()
 }
 
-func (cmd Command) describeAgent(client api.AgentServiceClient) {
+func (cmd Command) describeAgent(client api.AgentServiceClient) error {
 	req := &api.DescribeAgentRequest{AgentId: cmd.entityId}
 	resp, err := client.DescribeAgent(context.Background(), req)
 	if err != nil {
-		log.Fatalf("Error describing agent: %v", err)
+		return fmt.Errorf("error describing agent: %w", err)
 	}
 
 	data := [][]string{
@@ -68,13 +68,14 @@ func (cmd Command) describeAgent(client api.AgentServiceClient) {
 	}
 
 	output.PrintVertical(data)
+	return nil
 }
 
-func (cmd Command) describeRegion(client api.RegionServiceClient) {
+func (cmd Command) describeRegion(client api.RegionServiceClient) error {
 	req := &api.DescribeRegionRequest{RegionId: cmd.entityId}
 	resp, err := client.DescribeRegion(context.Background(), req)
 	if err != nil {
-		log.Fatalf("Error describing region: %v", err)
+		return fmt.Errorf("error describing region: %w", err)
 	}
 
 	data := [][]string{
@@ -90,4 +91,5 @@ func (cmd Command) describeRegion(client api.RegionServiceClient) {
 	}
 
 	output.PrintVertical(data)
+	return nil
 }

--- a/commands/list/cmd.go
+++ b/commands/list/cmd.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"doptctl/commands/output"
 	"fmt"
-	"log"
 
 	"google.golang.org/grpc"
 
@@ -23,21 +22,22 @@ func NewCommand(args []string) *Command {
 	return &Command{entityType: args[0]}
 }
 
-func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) error {
 	if cmd.showHelp {
 		cmd.Help()
-		return
+		return nil
 	}
 
 	switch cmd.entityType {
 	case "agents":
 		agentClient := doptApi.NewAgentServiceClient(conn)
-		listAgents(agentClient)
+		return listAgents(agentClient)
 	case "regions":
 		regionClient := doptApi.NewRegionServiceClient(conn)
-		listRegions(regionClient)
+		return listRegions(regionClient)
 	default:
 		cmd.Help()
+		return nil
 	}
 }
 
@@ -45,7 +45,7 @@ func (cmd Command) Help() {
 	Help()
 }
 
-func listAgents(client doptApi.AgentServiceClient) {
+func listAgents(client doptApi.AgentServiceClient) error {
 	var req = new(doptApi.ListAgentRequest)
 	ans, err := client.ListAgents(context.Background(), req)
 	if err == nil {
@@ -55,12 +55,13 @@ func listAgents(client doptApi.AgentServiceClient) {
 			data = append(data, []string{agent.Name, agent.Metaheuristic, agent.Path})
 		}
 		output.PrintTable(header, data)
+		return nil
 	} else {
-		log.Fatal(err)
+		return err
 	}
 }
 
-func listRegions(client doptApi.RegionServiceClient) {
+func listRegions(client doptApi.RegionServiceClient) error {
 	var req = new(doptApi.ListRegionsRequest)
 	ans, err := client.ListRegions(context.Background(), req)
 
@@ -76,7 +77,8 @@ func listRegions(client doptApi.RegionServiceClient) {
 			})
 		}
 		output.PrintTable(header, data)
+		return nil
 	} else {
-		log.Fatal(err)
+		return err
 	}
 }

--- a/commands/simulation/cmd.go
+++ b/commands/simulation/cmd.go
@@ -3,7 +3,6 @@ package simulation
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 
 	"google.golang.org/grpc"
@@ -24,23 +23,24 @@ func NewCommand(args []string) *Command {
 	return &Command{subCommand: args[0], params: args[1:]}
 }
 
-func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) {
+func (cmd Command) Execute(conn *grpc.ClientConn, opts map[string]string) error {
 	if cmd.showHelp {
 		cmd.Help()
-		return
+		return nil
 	}
 
 	switch cmd.subCommand {
 	case "status":
-		cmd.handleStatus(conn)
+		return cmd.handleStatus(conn)
 	case "start":
-		cmd.handleStart(conn)
+		return cmd.handleStart(conn)
 	case "stop":
-		cmd.handleStop(conn)
+		return cmd.handleStop(conn)
 	case "extractData":
-		cmd.handleExtractData(conn)
+		return cmd.handleExtractData(conn)
 	default:
 		cmd.Help()
+		return nil
 	}
 }
 
@@ -48,27 +48,28 @@ func (cmd Command) Help() {
 	Help()
 }
 
-func (cmd Command) handleStatus(conn *grpc.ClientConn) {
+func (cmd Command) handleStatus(conn *grpc.ClientConn) error {
 	client := doptApi.NewSimulationServiceClient(conn)
 	resp, err := client.StatSimulation(context.Background(), &doptApi.StatSimulationRequest{})
 	if err != nil {
-		log.Fatalf("Error getting simulation status: %v", err)
+		return fmt.Errorf("error getting simulation status: %w", err)
 	}
 	fmt.Printf("Status: %s\n", resp.Status)
 	if resp.Message != "" {
 		fmt.Printf("Message: %s\n", resp.Message)
 	}
+	return nil
 }
 
-func (cmd Command) handleStart(conn *grpc.ClientConn) {
+func (cmd Command) handleStart(conn *grpc.ClientConn) error {
 	if len(cmd.params) < 1 {
 		cmd.Help()
-		return
+		return nil
 	}
 	configPath := cmd.params[0]
 	content, err := os.ReadFile(configPath)
 	if err != nil {
-		log.Fatalf("Error reading configuration file: %v", err)
+		return fmt.Errorf("error reading configuration file: %w", err)
 	}
 
 	client := doptApi.NewSimulationServiceClient(conn)
@@ -76,26 +77,29 @@ func (cmd Command) handleStart(conn *grpc.ClientConn) {
 		ConfigurationFileContent: string(content),
 	})
 	if err != nil {
-		log.Fatalf("Error starting simulation: %v", err)
+		return fmt.Errorf("error starting simulation: %w", err)
 	}
 	fmt.Printf("Simulation started: %s\n", resp.Status)
 	if resp.Message != "" {
 		fmt.Printf("Message: %s\n", resp.Message)
 	}
+	return nil
 }
 
-func (cmd Command) handleStop(conn *grpc.ClientConn) {
+func (cmd Command) handleStop(conn *grpc.ClientConn) error {
 	client := doptApi.NewSimulationServiceClient(conn)
 	resp, err := client.StopSimulation(context.Background(), &doptApi.StopSimulationRequest{})
 	if err != nil {
-		log.Fatalf("Error stopping simulation: %v", err)
+		return fmt.Errorf("error stopping simulation: %w", err)
 	}
 	fmt.Printf("Simulation stopped: %s\n", resp.Status)
 	if resp.Message != "" {
 		fmt.Printf("Message: %s\n", resp.Message)
 	}
+	return nil
 }
 
-func (cmd Command) handleExtractData(conn *grpc.ClientConn) {
+func (cmd Command) handleExtractData(conn *grpc.ClientConn) error {
 	fmt.Println("ExtractData is not supported by the current API")
+	return nil
 }

--- a/doptimas/client/client.go
+++ b/doptimas/client/client.go
@@ -1,0 +1,19 @@
+package client
+
+import (
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func NewConnection(serverAddr string) (*grpc.ClientConn, error) {
+	var opts []grpc.DialOption
+
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	conn, err := grpc.Dial(serverAddr, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}


### PR DESCRIPTION
### Context
The doptctl CLI relied heavily on log.Fatal for error handling, leading to poor user experience (cluttered logs with timestamps) and un-idiomatic Go code. Additionally, gRPC connection logic was misplaced in the commands package.

### Technical Approach
- Created doptimas/client package to encapsulate gRPC connection logic.
- Refactored Command interface to return error.
- Replaced all log.Fatal calls with idiomatic error returns and wrapped them with context using fmt.Errorf.
- Updated central Run loop to handle errors and provide clean output to os.Stderr.
- Standardized context list output using output.PrintTable and added an active context indicator.

### Acceptance Criteria
- [x] All log.Fatal calls removed from commands and context packages.
- [x] Command.Execute returns error.
- [x] CLI provides clean, non-timestamped error messages.
- [x] context list displays a formatted table with an active indicator.
- [x] Code builds and all tests pass.

Fixes #15